### PR TITLE
Hotfix/fix did update null fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## v1.0.0 (2025-6-12)
+## v2.0.1 (2026-04-14)
+
+### 🐛 Bug Fixes
+    - Ledger Service Server
+        - Fixed an issue where the existing `did` and `role` values were not preserved during DID Document update
+        - Resolved a not-null constraint violation on the `did` column during DID Document version update
+        - Fixed a 500 error in the DID Document update flow (`propose-update-diddoc` → `request-update-diddoc`)
+
+## v2.0.0 (2025-06-12)
 
 ### 🚀 New Features
     - Ledger Service Server

--- a/source/did-ledger-service-server/build.gradle
+++ b/source/did-ledger-service-server/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'org.omnione.did'
-version = '2.0.0'
+version = '2.0.1'
 
 java {
     sourceCompatibility = '21'

--- a/source/did-ledger-service-server/src/main/java/org/omnione/did/repository/v1/service/DidServiceImpl.java
+++ b/source/did-ledger-service-server/src/main/java/org/omnione/did/repository/v1/service/DidServiceImpl.java
@@ -92,6 +92,8 @@ public class DidServiceImpl implements DidService {
         log.debug("\t--> Update did");
         Did updatedDid = didQueryService.save(Did.builder()
                 .id(previousDid.getId())
+                .did(previousDid.getDid())
+                .role(previousDid.getRole())
                 .status(DidDocStatus.ACTIVATE)
                 .version(newVersion)
                 .build());


### PR DESCRIPTION
## Description
Fixes a bug in the DID document update flow where the existing `did` and `role` values were not preserved in `DidServiceImpl.updateDidDoc()`.

This caused the `did` column to be saved as `null`, resulting in a not-null constraint violation and a 500 error during DID document update.

## Related Issue (Optional)
- Closes #5

## Changes
- Preserve existing `did` and `role` values when saving the updated `Did` entity
- Prevent `null value in column "did" violates not-null constraint` during DID document update
- Fix the 500 error in the DID document update flow (`propose-update-diddoc` → `request-update-diddoc`)

## Screenshots (Optional)

## Additional Comments (Optional)
This is a hotfix for the DID document update path only.